### PR TITLE
refactor(controllers): Pass DB connection through DI rather than global variable

### DIFF
--- a/config/db.go
+++ b/config/db.go
@@ -10,10 +10,8 @@ import (
 	"gorm.io/gorm"
 )
 
-var DB *gorm.DB
-
-func migrate() {
-	err := DB.AutoMigrate(api.User{}, &api.Breed{}, &api.Food{}, &api.Event{}, &api.Image{}, &api.Meal{}, &api.Medication{}, &api.Medicine{}, &api.Pet{}, &api.Species{})
+func migrate(db *gorm.DB) {
+	err := db.AutoMigrate(api.User{}, &api.Breed{}, &api.Food{}, &api.Event{}, &api.Image{}, &api.Meal{}, &api.Medication{}, &api.Medicine{}, &api.Pet{}, &api.Species{})
 	if err != nil {
 		log.Fatalf("An error occured while performing auto-migration: %v\n", err)
 	} else {
@@ -28,7 +26,6 @@ func InitDb() *gorm.DB {
 	if err != nil {
 		log.Fatalf("Error opening connection to database %v\n", err)
 	}
-	DB = db
-	migrate()
-	return DB
+	migrate(db)
+	return db
 }

--- a/controllers/breeds.go
+++ b/controllers/breeds.go
@@ -9,7 +9,7 @@ import (
 )
 
 type BreedService struct {
-	DB	*gorm.DB
+	DB *gorm.DB
 }
 
 func (s *BreedService) GetBreed(c *gin.Context) {

--- a/controllers/breeds.go
+++ b/controllers/breeds.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"pet-pal/api/config"
 	"pet-pal/api/models"
 	"strconv"
 
@@ -9,9 +8,11 @@ import (
 	"gorm.io/gorm"
 )
 
-func GetBreed(c *gin.Context) {
-	var DB *gorm.DB = config.DB
-	var breed *models.Breed
+type BreedService struct {
+	DB	*gorm.DB
+}
+
+func (s *BreedService) GetBreed(c *gin.Context) {
 	bid, err := strconv.Atoi(c.Param("breedId"))
 
 	if err != nil {
@@ -19,7 +20,7 @@ func GetBreed(c *gin.Context) {
 		c.Abort()
 		return
 	} else {
-		breed, err = models.RetrieveBreed(uint(bid), DB)
+		breed, err := models.RetrieveBreed(uint(bid), s.DB)
 		if err != nil {
 			c.JSON(500, err.Error())
 		} else {
@@ -28,15 +29,13 @@ func GetBreed(c *gin.Context) {
 	}
 }
 
-func GetBreeds(c *gin.Context) {
-	var DB *gorm.DB = config.DB
-	var breeds *[]models.Breed
+func (s *BreedService) GetBreeds(c *gin.Context) {
 	sid, err := strconv.Atoi(c.Query("speciesId"))
 
 	if err != nil {
 		c.JSON(400, "speciesId must be numeric")
 	} else {
-		breeds, err = models.RetrieveBreeds(uint(sid), DB)
+		breeds, err := models.RetrieveBreeds(uint(sid), s.DB)
 		if err != nil {
 			c.JSON(500, err.Error())
 		} else {

--- a/controllers/docs.go
+++ b/controllers/docs.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func ServeSwaggerUI (c *gin.Context) {
+func ServeSwaggerUI(c *gin.Context) {
 	c.HTML(http.StatusOK, "swagger-ui.html", gin.H{
 		"url": fmt.Sprintf("http://%s/static/docs/openapi.yml", c.Request.Host),
 	})

--- a/controllers/events.go
+++ b/controllers/events.go
@@ -1,22 +1,25 @@
 package controllers
 
 import (
-	"pet-pal/api/config"
 	"pet-pal/api/models"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
-func GetEvents(c *gin.Context) {
-	DB := config.DB
+type EventService struct {
+	DB *gorm.DB
+}
+
+func (s *EventService) GetEvents(c *gin.Context) {
 	userId, userExists := c.Get(GIN_CONTEXT_USER_KEY)
 
 	if !userExists {
 		c.JSON(400, missingUserId)
 		return
 	}
-	events, err := models.RetrieveEvents(uint(userId.(int)), DB)
+	events, err := models.RetrieveEvents(uint(userId.(int)), s.DB)
 	if err != nil {
 		c.JSON(500, err.Error())
 		return
@@ -24,8 +27,7 @@ func GetEvents(c *gin.Context) {
 	c.JSON(200, events)
 }
 
-func PostEvent(c *gin.Context) {
-	DB := config.DB
+func (s *EventService) PostEvent(c *gin.Context) {
 	var event *models.Event = &models.Event{}
 	userId, userExists := c.Get(GIN_CONTEXT_USER_KEY)
 
@@ -39,7 +41,7 @@ func PostEvent(c *gin.Context) {
 		c.JSON(400, err.Error())
 		return
 	}
-	if err := models.CreateEvent(event, DB); err != nil {
+	if err := models.CreateEvent(event, s.DB); err != nil {
 		c.JSON(500, err.Error())
 		return
 	}
@@ -47,8 +49,7 @@ func PostEvent(c *gin.Context) {
 	c.JSON(200, &event)
 }
 
-func PutEvent(c *gin.Context) {
-	DB := config.DB
+func (s *EventService) PutEvent(c *gin.Context) {
 	var event *models.Event = &models.Event{}
 	userId, userExists := c.Get(GIN_CONTEXT_USER_KEY)
 	eventId, err := strconv.Atoi(c.Param("eventId"))
@@ -66,15 +67,14 @@ func PutEvent(c *gin.Context) {
 		c.JSON(400, err.Error())
 		return
 	}
-	if event, err = models.UpdateEvent(uint(userId.(int)), event, DB); err != nil {
+	if event, err = models.UpdateEvent(uint(userId.(int)), event, s.DB); err != nil {
 		c.JSON(500, err.Error())
 		return
 	}
 	c.JSON(200, event)
 }
 
-func DeleteEvent(c *gin.Context) {
-	DB := config.DB
+func (s *EventService) DeleteEvent(c *gin.Context) {
 	userId, userExists := c.Get(GIN_CONTEXT_USER_KEY)
 	eventId, err := strconv.Atoi(c.Param("eventId"))
 
@@ -86,7 +86,7 @@ func DeleteEvent(c *gin.Context) {
 		c.JSON(400, idMustBeNumeric)
 		return
 	}
-	if err = models.DeleteEvent(uint(userId.(int)), uint(eventId), DB); err != nil {
+	if err = models.DeleteEvent(uint(userId.(int)), uint(eventId), s.DB); err != nil {
 		c.JSON(500, err.Error())
 		return
 	}

--- a/controllers/foods.go
+++ b/controllers/foods.go
@@ -9,7 +9,7 @@ import (
 )
 
 type FoodService struct {
-	DB	*gorm.DB
+	DB *gorm.DB
 }
 
 func (s *FoodService) GetFood(c *gin.Context) {

--- a/controllers/foods.go
+++ b/controllers/foods.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"pet-pal/api/config"
 	"pet-pal/api/models"
 	"strconv"
 
@@ -9,16 +8,17 @@ import (
 	"gorm.io/gorm"
 )
 
-func GetFood(c *gin.Context) {
-	var food *models.Food
-	var DB *gorm.DB = config.DB
+type FoodService struct {
+	DB	*gorm.DB
+}
 
+func (s *FoodService) GetFood(c *gin.Context) {
 	foodId, err := strconv.Atoi(c.Param("foodId"))
 
 	if err != nil {
 		c.JSON(400, "Food ID must be numeric.")
 	} else {
-		food, err = models.RetrieveFood(uint(foodId), DB)
+		food, err := models.RetrieveFood(uint(foodId), s.DB)
 		if err != nil {
 			c.JSON(500, err.Error())
 		} else {
@@ -27,16 +27,13 @@ func GetFood(c *gin.Context) {
 	}
 }
 
-func GetFoods(c *gin.Context) {
-	var foods *[]models.Food
-	var DB *gorm.DB = config.DB
-
+func (s *FoodService) GetFoods(c *gin.Context) {
 	speciesId, err := strconv.Atoi(c.Query("speciesId"))
 
 	if err != nil {
 		c.JSON(400, "Species ID must be numeric.")
 	} else {
-		foods, err = models.RetrieveFoods(uint(speciesId), DB)
+		foods, err := models.RetrieveFoods(uint(speciesId), s.DB)
 		if err != nil {
 			c.JSON(500, err.Error())
 		} else {

--- a/controllers/images.go
+++ b/controllers/images.go
@@ -10,7 +10,7 @@ import (
 )
 
 type ImageService struct {
-	DB	*gorm.DB
+	DB *gorm.DB
 }
 
 func (s *ImageService) GetImagesByPet(c *gin.Context) {

--- a/controllers/medicines.go
+++ b/controllers/medicines.go
@@ -9,7 +9,7 @@ import (
 )
 
 type MedicineService struct {
-	DB	*gorm.DB
+	DB *gorm.DB
 }
 
 func (s *MedicineService) GetMedicine(c *gin.Context) {

--- a/controllers/medicines.go
+++ b/controllers/medicines.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"pet-pal/api/config"
 	"pet-pal/api/models"
 	"strconv"
 
@@ -9,16 +8,17 @@ import (
 	"gorm.io/gorm"
 )
 
-func GetMedicine(c *gin.Context) {
-	var medicine *models.Medicine
-	var DB *gorm.DB = config.DB
+type MedicineService struct {
+	DB	*gorm.DB
+}
 
+func (s *MedicineService) GetMedicine(c *gin.Context) {
 	medId, err := strconv.Atoi(c.Param("medicineId"))
 
 	if err != nil {
 		c.JSON(400, "Medicine ID must be numeric.")
 	} else {
-		medicine, err = models.GetMedicine(uint(medId), DB)
+		medicine, err := models.GetMedicine(uint(medId), s.DB)
 		if err != nil {
 			c.JSON(500, err.Error())
 		} else {
@@ -27,16 +27,13 @@ func GetMedicine(c *gin.Context) {
 	}
 }
 
-func GetMedicines(c *gin.Context) {
-	var medicines *[]models.Medicine
-	var DB *gorm.DB = config.DB
-
+func (s *MedicineService) GetMedicines(c *gin.Context) {
 	speciesId, err := strconv.Atoi(c.Query("speciesId"))
 
 	if err != nil {
 		c.JSON(400, "Species ID must be numeric.")
 	} else {
-		medicines, err = models.GetMedicines(uint(speciesId), DB)
+		medicines, err := models.GetMedicines(uint(speciesId), s.DB)
 		if err != nil {
 			c.JSON(500, err.Error())
 		} else {

--- a/controllers/pets.go
+++ b/controllers/pets.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"pet-pal/api/config"
 	"pet-pal/api/models"
 	"strconv"
 
@@ -9,10 +8,11 @@ import (
 	"gorm.io/gorm"
 )
 
-func GetPet(c *gin.Context) {
-	var DB *gorm.DB = config.DB
-	var pet *models.Pet
+type PetService struct {
+	DB *gorm.DB
+}
 
+func (s *PetService) GetPet(c *gin.Context) {
 	uid, userExists := c.Get("user")
 	pid, err := strconv.Atoi(c.Param("petId"))
 
@@ -21,24 +21,19 @@ func GetPet(c *gin.Context) {
 	} else if err != nil {
 		c.JSON(400, idMustBeNumeric)
 	} else {
-		pet, err = models.RetrievePet(uint(pid), uint(uid.(int)), DB)
+		pet, err := models.RetrievePet(uint(pid), uint(uid.(int)), s.DB)
 		if err != nil {
 			c.JSON(500, err.Error())
 		} else {
 			c.JSON(200, &pet)
 		}
 	}
-
 }
 
-func GetPets(c *gin.Context) {
-	var DB *gorm.DB = config.DB
-	var pets *[]models.Pet
-	var err error
-
+func (s *PetService) GetPets(c *gin.Context) {
 	uid, userExists := c.Get("user")
 	if userExists {
-		pets, err = models.RetrievePets(uint(uid.(int)), DB)
+		pets, err := models.RetrievePets(uint(uid.(int)), s.DB)
 		if err != nil {
 			c.JSON(500, err.Error())
 		} else {
@@ -47,18 +42,17 @@ func GetPets(c *gin.Context) {
 	}
 }
 
-func PostPet(c *gin.Context) {
-	var DB *gorm.DB = config.DB
+func (s *PetService) PostPet(c *gin.Context) {
 	var pet *models.Pet
-	var err error
+
 	uid, userExists := c.Get("user")
 	if !userExists {
 		c.JSON(400, missingUserId)
-	} else if err = c.BindJSON(&pet); err != nil {
+	} else if err := c.BindJSON(&pet); err != nil {
 		c.JSON(400, err.Error())
 	} else {
 		pet.UserID = uint(uid.(int))
-		if err = models.CreatePet(pet, DB); err != nil {
+		if err = models.CreatePet(pet, s.DB); err != nil {
 			c.JSON(500, err.Error())
 		} else {
 			c.JSON(200, &pet)
@@ -66,10 +60,8 @@ func PostPet(c *gin.Context) {
 	}
 }
 
-func PutPet(c *gin.Context) {
-	var err error
+func (s *PetService) PutPet(c *gin.Context) {
 	var pet *models.Pet
-	var DB *gorm.DB = config.DB
 
 	uid, userExists := c.Get("user")
 	pid, err := strconv.Atoi(c.Param("petId"))
@@ -79,23 +71,21 @@ func PutPet(c *gin.Context) {
 		c.JSON(400, idMustBeNumeric)
 	} else if err = c.BindJSON(&pet); err != nil {
 		c.JSON(400, err.Error())
-	} else if pet, err = models.UpdatePet(uint(uid.(int)), uint(pid), pet, DB); err != nil {
+	} else if pet, err = models.UpdatePet(uint(uid.(int)), uint(pid), pet, s.DB); err != nil {
 		c.JSON(500, err.Error())
 	} else {
 		c.JSON(201, &pet)
 	}
 }
 
-func DeletePet(c *gin.Context) {
-	var DB *gorm.DB = config.DB
-
+func (s *PetService) DeletePet(c *gin.Context) {
 	uid, userExists := c.Get("user")
 	pid, err := strconv.Atoi(c.Param("petId"))
 	if err != nil {
 		c.JSON(400, idMustBeNumeric)
 	}
 	if userExists {
-		err = models.DeletePet(uint(pid), uint(uid.(int)), DB)
+		err = models.DeletePet(uint(pid), uint(uid.(int)), s.DB)
 		if err != nil {
 			c.JSON(500, err.Error())
 		} else {

--- a/controllers/ping.go
+++ b/controllers/ping.go
@@ -1,0 +1,15 @@
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type PingService struct {}
+
+func (service *PingService) Ping(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"message": "pong",
+	})
+}

--- a/controllers/ping.go
+++ b/controllers/ping.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type PingService struct {}
+type PingService struct{}
 
 func (service *PingService) Ping(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{

--- a/controllers/species.go
+++ b/controllers/species.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"pet-pal/api/config"
 	"pet-pal/api/models"
 	"strconv"
 
@@ -9,16 +8,17 @@ import (
 	"gorm.io/gorm"
 )
 
-func GetSpecies(c *gin.Context) {
-	var DB *gorm.DB = config.DB
-	var species *models.Species
+type SpeciesService struct {
+	DB	*gorm.DB
+}
 
+func (s *SpeciesService) GetSpecies(c *gin.Context) {
 	sid, err := strconv.Atoi(c.Param("speciesId"))
 
 	if err != nil {
 		c.JSON(400, "Species ID must be numeric")
 	} else {
-		if species, err = models.RetrieveSpecies(uint(sid), DB); err != nil {
+		if species, err := models.RetrieveSpecies(uint(sid), s.DB); err != nil {
 			c.JSON(500, "Internal Server Error")
 		} else {
 			c.JSON(200, species)

--- a/controllers/species.go
+++ b/controllers/species.go
@@ -9,7 +9,7 @@ import (
 )
 
 type SpeciesService struct {
-	DB	*gorm.DB
+	DB *gorm.DB
 }
 
 func (s *SpeciesService) GetSpecies(c *gin.Context) {

--- a/controllers/users.go
+++ b/controllers/users.go
@@ -9,7 +9,7 @@ import (
 )
 
 type UserService struct {
-	DB	*gorm.DB
+	DB *gorm.DB
 }
 
 func (s *UserService) PostUser(c *gin.Context) {

--- a/controllers/users.go
+++ b/controllers/users.go
@@ -2,28 +2,23 @@ package controllers
 
 import (
 	"fmt"
-	"pet-pal/api/config"
 	"pet-pal/api/models"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
 
-func GetUserIdFromFirebaseId(tokenUID string) uint {
-	var DB *gorm.DB = config.DB
-	var user models.User
-	DB.Where("account_id = ?", tokenUID).First(&user)
-	return user.ID
+type UserService struct {
+	DB	*gorm.DB
 }
 
-func PostUser(c *gin.Context) {
-	var DB *gorm.DB = config.DB
+func (s *UserService) PostUser(c *gin.Context) {
 	var user *models.User
 
 	if err := c.BindJSON(&user); err != nil {
 		return
 	}
-	err := models.CreateUser(user, DB)
+	err := models.CreateUser(user, s.DB)
 	if err != nil {
 		c.JSON(500, "Internal Server Error")
 	} else {
@@ -31,14 +26,10 @@ func PostUser(c *gin.Context) {
 	}
 }
 
-func GetUser(c *gin.Context) {
-	var DB *gorm.DB = config.DB
-	var user *models.User
-	var err error
-
+func (s *UserService) GetUser(c *gin.Context) {
 	userId, exists := c.Get("user")
 	if exists {
-		user, err = models.RetrieveUser(uint(userId.(int)), DB)
+		user, err := models.RetrieveUser(uint(userId.(int)), s.DB)
 		if err != nil {
 			c.JSON(500, "Internal Server Error")
 		} else {
@@ -49,12 +40,11 @@ func GetUser(c *gin.Context) {
 	}
 }
 
-func DeleteUser(c *gin.Context) {
-	var DB *gorm.DB = config.DB
+func (s *UserService) DeleteUser(c *gin.Context) {
 	userId, exists := c.Get("user")
 
 	if exists {
-		err := models.DeleteUser(uint(userId.(int)), DB)
+		err := models.DeleteUser(uint(userId.(int)), s.DB)
 		if err != nil {
 			c.JSON(500, "Internal Server Error")
 		} else {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"pet-pal/api/config"
 	"pet-pal/api/controllers"
 	"pet-pal/api/middleware"
@@ -100,5 +101,5 @@ func main() {
 		}
 	}
 
-	router.Run(":3000")
+	http.ListenAndServe(":3000", router)
 }

--- a/main.go
+++ b/main.go
@@ -8,14 +8,18 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func pingHandler(c *gin.Context) {
-	c.JSON(200, gin.H{
-		"message": "pong",
-	})
-}
-
 func main() {
-	config.InitDb()
+	db := config.InitDb()
+
+	pingService := &controllers.PingService{}
+	userService := &controllers.UserService{DB: db}
+	petService := &controllers.PetService{DB: db}
+	speciesService := &controllers.SpeciesService{DB: db}
+	breedService := &controllers.BreedService{DB: db}
+	foodService := &controllers.FoodService{DB: db}
+	medicineService := &controllers.MedicineService{DB: db}
+	eventService := &controllers.EventService{DB: db}
+	imageService := &controllers.ImageService{DB: db}
 
 	router := gin.Default()
 
@@ -23,48 +27,47 @@ func main() {
 	router.Static("/static", "./static")
 
 	router.GET("/", controllers.ServeSwaggerUI)
-	router.GET("/ping", pingHandler)
+	router.GET("/ping", pingService.Ping)
 
-	var api *gin.RouterGroup = router.Group("/api")
+	api := router.Group("/api")
 	{
-		// api.Use(middleware.TokenAuth(authClient, DB))
 		api.Use(middleware.TempUserAuth)
-		var users *gin.RouterGroup = api.Group("/users")
+		users := api.Group("/users")
 		{
-			users.GET("/", controllers.GetUser)
-			users.POST("/", controllers.PostUser)
-			users.DELETE("/", controllers.DeleteUser)
+			users.GET("/", userService.GetUser)
+			users.POST("/", userService.PostUser)
+			users.DELETE("/", userService.DeleteUser)
 		}
-		var pets *gin.RouterGroup = api.Group("/pets")
+		pets := api.Group("/pets")
 		{
-			pets.GET("/", controllers.GetPets)
-			pets.GET("/:petId", controllers.GetPet)
-			pets.POST("/", controllers.PostPet)
-			pets.PUT("/:petId", controllers.PutPet)
-			pets.DELETE("/:petId", controllers.DeletePet)
+			pets.GET("/", petService.GetPets)
+			pets.GET("/:petId", petService.GetPet)
+			pets.POST("/", petService.PostPet)
+			pets.PUT("/:petId", petService.PutPet)
+			pets.DELETE("/:petId", petService.DeletePet)
 		}
-		var species *gin.RouterGroup = api.Group("/species")
+		species := api.Group("/species")
 		{
-			species.GET("/:speciesId", controllers.GetSpecies)
+			species.GET("/:speciesId", speciesService.GetSpecies)
 		}
-		var breeds *gin.RouterGroup = api.Group("/breeds")
+		breeds := api.Group("/breeds")
 		{
-			breeds.GET("/", controllers.GetBreeds)
-			breeds.GET("/:breedId", controllers.GetBreed)
+			breeds.GET("/", breedService.GetBreeds)
+			breeds.GET("/:breedId", breedService.GetBreed)
 		}
-		var foods *gin.RouterGroup = api.Group("/foods")
+		foods := api.Group("/foods")
 		{
-			foods.GET("/:foodId", controllers.GetFood)
-			foods.GET("/", controllers.GetFoods)
+			foods.GET("/:foodId", foodService.GetFood)
+			foods.GET("/", foodService.GetFoods)
 		}
-		var medicines *gin.RouterGroup = api.Group("/medicines")
+		medicines := api.Group("/medicines")
 		{
-			medicines.GET("/:medicineId", controllers.GetMedicine)
-			medicines.GET("/", controllers.GetMedicines)
+			medicines.GET("/:medicineId", medicineService.GetMedicine)
+			medicines.GET("/", medicineService.GetMedicines)
 		}
 		// for these two groups, could we want to have a new router group like
 		// petMeals = *gin.RouterGroup = api.Group("/:mealId") ?
-		var meals *gin.RouterGroup = api.Group("/meals")
+		meals := api.Group("/meals")
 		{
 			meals.GET("/:mealId")
 			meals.GET("/pet/:petId")
@@ -73,7 +76,7 @@ func main() {
 			meals.DELETE("/:mealId")
 
 		}
-		var medications *gin.RouterGroup = api.Group("/medications")
+		medications := api.Group("/medications")
 		{
 			medications.GET("/:medicationId")
 			medications.GET("/pets/:petId")
@@ -81,19 +84,19 @@ func main() {
 			medications.POST("/")
 			medications.DELETE("/:medicationId")
 		}
-		var events *gin.RouterGroup = api.Group("/events")
+		events := api.Group("/events")
 		{
-			events.GET("/", controllers.GetEvents)
-			events.POST("/", controllers.PostEvent)
-			events.PUT("/:eventId", controllers.PutEvent)
-			events.DELETE("/:eventId", controllers.DeleteEvent)
+			events.GET("/", eventService.GetEvents)
+			events.POST("/", eventService.PostEvent)
+			events.PUT("/:eventId", eventService.PutEvent)
+			events.DELETE("/:eventId", eventService.DeleteEvent)
 		}
-		var images *gin.RouterGroup = api.Group("/images")
+		images := api.Group("/images")
 		{
-			images.GET("/pets/:petId", controllers.GetImagesByPet)
-			images.GET("/users", controllers.GetImagesByUser)
-			images.POST("/", controllers.PostImage)
-			images.DELETE("/:imageId", controllers.DeleteImage)
+			images.GET("/pets/:petId", imageService.GetImagesByPet)
+			images.GET("/users", imageService.GetImagesByUser)
+			images.POST("/", imageService.PostImage)
+			images.DELETE("/:imageId", imageService.DeleteImage)
 		}
 	}
 

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -1,31 +1,10 @@
 package middleware
 
 import (
-	"context"
-	"pet-pal/api/controllers"
 	"strconv"
-	"strings"
 
-	"firebase.google.com/go/v4/auth"
 	"github.com/gin-gonic/gin"
-	"gorm.io/gorm"
 )
-
-func TokenAuth(client *auth.Client, db *gorm.DB) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		authHeader := c.Request.Header.Get("Authorization")
-		headerToken := strings.Replace(authHeader, "Bearer ", "", 1)
-		token, err := client.VerifyIDToken(context.Background(), headerToken)
-		if err != nil {
-			c.JSON(400, gin.H{"error": "Invalid token"})
-			c.Abort()
-			return
-		}
-		var userId uint = controllers.GetUserIdFromFirebaseId(token.UID)
-		c.Set("user", userId)
-		c.Next()
-	}
-}
 
 func TempUserAuth(c *gin.Context) {
 	authHeader := c.Request.Header.Get("Authorization")

--- a/models/breeds.go
+++ b/models/breeds.go
@@ -4,20 +4,20 @@ import "gorm.io/gorm"
 
 type Breed struct {
 	gorm.Model
-	SpeciesID    uint `json:"speciesId"`
-	Species      Species`json:"-"`
-	Name         string `json:"name"`
-	Size         string `json:"size"`
-	HeightMale   string `json:"heightMale"`
-	HeightFemale string `json:"heightFemale"`
-	WeightMale   string `json:"weightMale"`
-	WeightFemale string `json:"weightFemale"`
-	Coat         string `json:"coat"`
-	CoatDesc     string `json:"coatDesc"`
-	Colors       string `json:"colors"`
-	ColorsDesc   string `json:"colorsDesc"`
-	Energy       string `json:"energy"`
-	Activities   string `json:"activities"`
+	SpeciesID    uint    `json:"speciesId"`
+	Species      Species `json:"-"`
+	Name         string  `json:"name"`
+	Size         string  `json:"size"`
+	HeightMale   string  `json:"heightMale"`
+	HeightFemale string  `json:"heightFemale"`
+	WeightMale   string  `json:"weightMale"`
+	WeightFemale string  `json:"weightFemale"`
+	Coat         string  `json:"coat"`
+	CoatDesc     string  `json:"coatDesc"`
+	Colors       string  `json:"colors"`
+	ColorsDesc   string  `json:"colorsDesc"`
+	Energy       string  `json:"energy"`
+	Activities   string  `json:"activities"`
 }
 
 func RetrieveBreeds(speciesId uint, DB *gorm.DB) (breeds *[]Breed, err error) {

--- a/models/users.go
+++ b/models/users.go
@@ -12,12 +12,6 @@ type User struct {
 	Pets      []Pet  `gorm:"constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
 }
 
-func GetUserIdFromFirebaseId(tokenUID string, DB *gorm.DB) (uint, error) {
-	var user User
-	var err error = DB.Where("accountID = ?", tokenUID).First(&user).Error
-	return user.ID, err
-}
-
 func CreateUser(user *User, DB *gorm.DB) error {
 	var err error = DB.Create(&user).Error
 	return err


### PR DESCRIPTION
Use dependency injection to pass the Gorm DB connection to handlers that need it. Redefine controller functions as methods on a Service struct that contains a reference to `gorm.DB`, instead of accessing a global variable.

Inspired by [this blog post](https://www.alexedwards.net/blog/organising-database-access) and the `Dependency Injection` section of "Let's Go"

Additionally replace some assignment operators with the "short variable declaration" syntax `:=`